### PR TITLE
Reduce the blocking time of the write lock when deleting space

### DIFF
--- a/src/kvstore/NebulaStore.cpp
+++ b/src/kvstore/NebulaStore.cpp
@@ -516,13 +516,17 @@ std::shared_ptr<Part> NebulaStore::newPart(GraphSpaceID spaceId,
 }
 
 void NebulaStore::removeSpace(GraphSpaceID spaceId) {
-  folly::RWSpinLock::WriteHolder wh(&lock_);
-  if (beforeRemoveSpace_) {
-    beforeRemoveSpace_(spaceId);
+  {
+    folly::RWSpinLock::WriteHolder wh(&lock_);
+    if (beforeRemoveSpace_) {
+      beforeRemoveSpace_(spaceId);
+    }
   }
 
-  auto spaceIt = this->spaces_.find(spaceId);
-  if (spaceIt != this->spaces_.end()) {
+  auto spaceOr = space(spaceId);
+  if (ok(spaceOr)) {
+    folly::RWSpinLock::WriteHolder wh(&lock_);
+    auto spaceIt = this->spaces_.find(spaceId);
     for (auto& [partId, part] : spaceIt->second->parts_) {
       // before calling removeSpace, meta client would call removePart to remove all parts in
       // meta cache, which do not contain learners, so we remove them here
@@ -530,6 +534,10 @@ void NebulaStore::removeSpace(GraphSpaceID spaceId) {
         removePart(spaceId, partId, false);
       }
     }
+    this->spaces_.erase(spaceIt);
+  }
+  if (ok(spaceOr)) {
+    auto spaceIt = value(spaceOr);
     auto& engines = spaceIt->second->engines_;
     for (auto& engine : engines) {
       auto parts = engine->allParts();
@@ -538,14 +546,13 @@ void NebulaStore::removeSpace(GraphSpaceID spaceId) {
       }
       CHECK_EQ(0, engine->totalPartsNum());
     }
-    CHECK(spaceIt->second->parts_.empty());
+    CHECK(spaceIt->parts_.empty());
     std::vector<std::string> enginePaths;
     if (FLAGS_auto_remove_invalid_space) {
       for (auto& engine : engines) {
         enginePaths.emplace_back(engine->getDataRoot());
       }
     }
-    this->spaces_.erase(spaceIt);
     if (FLAGS_auto_remove_invalid_space) {
       for (const auto& path : enginePaths) {
         removeSpaceDir(path);


### PR DESCRIPTION
When the number of parts of a space is relatively large and the amount of data written is also large, it will block for a long time in the removeSpace function when deleting the space. Affect business read and write

<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 

#### Description:


## How do you solve it?



## Special notes for your reviewer, ex. impact of this fix, design document, etc:



## Checklist:
Tests:
- [ ] Unit test(positive and negative cases)
- [ ] Function test
- [ ] Performance test
- [ ] N/A

Affects:
- [ ] Documentation affected (Please add the label if documentation needs to be modified.)
- [ ] Incompatibility (If it breaks the compatibility, please describe it and add the label.）
- [ ] If it's needed to cherry-pick (If cherry-pick to some branches is required, please label the destination version(s).)
- [ ] Performance impacted: Consumes more CPU/Memory


## Release notes:

Please confirm whether to be reflected in release notes and how to describe:
> ex. Fixed the bug .....
